### PR TITLE
Fix 2 - add functions - add metadata fields file

### DIFF
--- a/bulkDGD/execs/dgd_get_recount3_data.py
+++ b/bulkDGD/execs/dgd_get_recount3_data.py
@@ -286,6 +286,33 @@ def main():
         sys.exit(errstr)
 
 
+
+    #-------------- Parse sample_attributes to metadata ---------------#
+
+
+    # Try to parse sample_attributes and add the data to columns
+    if input_project_name == 'sra':
+        try:
+            df_metadata = \
+                recount3.add_sample_attributes_to_metadata(
+                    df_metadata,
+                    save_metadata = save_metadata,
+                    project_name = input_project_name,
+                    samples_category = input_samples_category,
+                    wd = wd)
+
+        # If something went wrong
+        except Exception as e:
+
+            # Warn the user and exit
+            errstr = \
+                "It was not possible to parse the sample_attribute data for the " \
+                f"'{input_samples_category}' samples from the Recount3 " \
+                f"platform. Error: {e}"
+            logger.exception(errstr)
+            sys.exit(errstr)
+
+
     #---------------------- Filter by metadata -----------------------#
 
     

--- a/bulkDGD/recount3/data/sra_metadata_fields__project_specific.txt
+++ b/bulkDGD/recount3/data/sra_metadata_fields__project_specific.txt
@@ -1,0 +1,54 @@
+# Fields found in the SRA metadata files downloaded from the Recount3 platform.
+ 
+rail_id
+external_id
+study
+sample_acc
+experiment_acc
+submission_acc
+submission_center
+submission_lab
+study_title
+study_abstract
+study_description
+experiment_title
+design_description
+sample_description
+library_name
+library_strategy
+library_source
+library_selection
+library_layout
+paired_nominal_length
+paired_nominal_stdev
+library_construction_protocol
+platform_model
+sample_attributes
+experiment_attributes
+spot_length
+sample_name
+sample_title
+sample_bases
+sample_spots
+run_published
+size
+run_total_bases
+run_total_spots
+num_reads
+num_spots
+read_info
+run_alias
+run_center_name
+run_broker_name
+run_center
+
+# Fields found in the sample_attributes column in the project speciic metadata.
+ 
+cell type
+drug treatment
+gender
+library barcode
+response group
+source_name
+subject
+timepoint

--- a/bulkDGD/recount3/defaults.py
+++ b/bulkDGD/recount3/defaults.py
@@ -46,6 +46,11 @@ RECOUNT3_METADATA_FIELDS_FILE = \
                            "data/tcga_metadata_fields.txt"),
      "sra" : os.path.join(os.path.dirname(__file__),
                           "data/sra_metadata_fields.txt")}
+
+# File containing the list of fields found in the metadata
+RECOUNT3_METADATA_FIELDS_FILE__PROJECT_SPECIFIC = \
+    {"sra" : os.path.join(os.path.dirname(__file__),
+                          "data/sra_metadata_fields__project_specific.txt")}
     
 # URL pointing to where the RNA-seq data for the samples
 # are stored on the Recount3 platform


### PR DESCRIPTION
To be able to filter by query for SRA project data, functions were added to to Recount3.utils for parsing the SRA specific attributes as well as for handling the metadata_fields for the individual SRA data download requests. A new SRA project specific file for metadata_fields was added, and the path to this was added in Recount3.defaults. The feature was implemented in execs.dgd_get_recount3_data. Additions was added to Recount3.utils for handling the files saved to disc in relation to SRA data downloads with queries.