### PR TITLE
Fix 4 add bulk recount3 download feature

### DIFF
--- a/bulkDGD/execs/dgd_get_recount3_data.py
+++ b/bulkDGD/execs/dgd_get_recount3_data.py
@@ -286,6 +286,33 @@ def main():
         sys.exit(errstr)
 
 
+
+    #-------------- Parse sample_attributes to metadata ---------------#
+
+
+    # Try to parse sample_attributes and add the data to columns
+    if input_project_name == 'sra':
+        try:
+            df_metadata = \
+                recount3.add_sample_attributes_to_metadata(
+                    df_metadata,
+                    save_metadata = save_metadata,
+                    project_name = input_project_name,
+                    samples_category = input_samples_category,
+                    wd = wd)
+
+        # If something went wrong
+        except Exception as e:
+
+            # Warn the user and exit
+            errstr = \
+                "It was not possible to parse the sample_attribute data for the " \
+                f"'{input_samples_category}' samples from the Recount3 " \
+                f"platform. Error: {e}"
+            logger.exception(errstr)
+            sys.exit(errstr)
+
+
     #---------------------- Filter by metadata -----------------------#
 
     

--- a/bulkDGD/execs/dgd_get_recount3_data__wrapper.py
+++ b/bulkDGD/execs/dgd_get_recount3_data__wrapper.py
@@ -1,0 +1,63 @@
+#!/Users/fwv895/miniforge3/bin/python3.10
+
+import os
+import sys
+import glob
+import pandas as pd
+
+from concurrent.futures import ProcessPoolExecutor
+from functools import partial
+
+from bulkDGD import recount3
+from bulkDGD.execs import dgd_get_recount3_data as dgd_get_recount3_data__cli
+
+
+
+# --------- parse info from pd.series to bulkDGD.execs.dgd_get_recount3_data function ----------
+      
+
+def get_recount3_data__process_row(row, output_folder):
+    original_argv = sys.argv
+
+    sys.argv = [
+        'dgd_get_recount3_data.py',
+        '-ip', row['input_project_name'],
+        '-is', row['input_samples_category'],
+        '-d', f"{output_folder}", #/{row['input_project_name']}_{row['input_samples_category']}.csv
+        '-qs', row['query_string'],
+        '-sm',
+        '-sg',
+        '-lc',
+        '-v'
+        # ,
+        # '-vv'
+    ]
+
+    # Attempt to call the main function of the CLI module
+    try:
+        # print(f"\n\nAttempting download of {row['input_samples_category']}\n")
+        dgd_get_recount3_data__cli.main()
+        print(f"Successful download of file: {output_folder}/{row['input_project_name']}_{row['input_samples_category']}.csv\n\n\n")
+    except Exception as e:
+        print(f"\n\nAn error occurred: {e}\n\n\n")
+    finally:
+        # Restore the original sys.argv
+        sys.argv = original_argv
+
+
+
+
+# -------------------------- run dgd_get_recount3_data for each row in df -------------------
+
+def get_recount3_data(data, output_folder, project_id_subset=None):
+      # get data if data is path, otherwise just constrain format of DataFrame
+      df = recount3.util.get_recount3_data_input_file(data=data, project_id_subset=project_id_subset)
+      for n_object,row in enumerate(df.to_dict('records')):
+        print(f"\n\n\nInitiating download of object number {n_object + 1}\n{row['input_samples_category']}\n\n")
+        get_recount3_data__process_row(row, output_folder)
+
+
+
+
+if __name__ == '__main__':
+    main()

--- a/bulkDGD/recount3/data/sra_metadata_fields__project_specific.txt
+++ b/bulkDGD/recount3/data/sra_metadata_fields__project_specific.txt
@@ -1,0 +1,54 @@
+# Fields found in the SRA metadata files downloaded from the Recount3 platform.
+ 
+rail_id
+external_id
+study
+sample_acc
+experiment_acc
+submission_acc
+submission_center
+submission_lab
+study_title
+study_abstract
+study_description
+experiment_title
+design_description
+sample_description
+library_name
+library_strategy
+library_source
+library_selection
+library_layout
+paired_nominal_length
+paired_nominal_stdev
+library_construction_protocol
+platform_model
+sample_attributes
+experiment_attributes
+spot_length
+sample_name
+sample_title
+sample_bases
+sample_spots
+run_published
+size
+run_total_bases
+run_total_spots
+num_reads
+num_spots
+read_info
+run_alias
+run_center_name
+run_broker_name
+run_center
+
+# Fields found in the sample_attributes column in the project speciic metadata.
+ 
+cell type
+drug treatment
+gender
+library barcode
+response group
+source_name
+subject
+timepoint

--- a/bulkDGD/recount3/defaults.py
+++ b/bulkDGD/recount3/defaults.py
@@ -46,6 +46,11 @@ RECOUNT3_METADATA_FIELDS_FILE = \
                            "data/tcga_metadata_fields.txt"),
      "sra" : os.path.join(os.path.dirname(__file__),
                           "data/sra_metadata_fields.txt")}
+
+# File containing the list of fields found in the metadata
+RECOUNT3_METADATA_FIELDS_FILE__PROJECT_SPECIFIC = \
+    {"sra" : os.path.join(os.path.dirname(__file__),
+                          "data/sra_metadata_fields__project_specific.txt")}
     
 # URL pointing to where the RNA-seq data for the samples
 # are stored on the Recount3 platform


### PR DESCRIPTION
I added a wrapper for the dgd_get_recount3_data for bulk download using a csv file as input. This makes it possible to download in bulk while still filtering using dataset specific query_strings. I also added a getter function for the CSV file to recount3/utils, as it seemed more fitting to put it there.